### PR TITLE
!fix Missed semicolon on scss variables

### DIFF
--- a/_sass/default/base/_variables.scss
+++ b/_sass/default/base/_variables.scss
@@ -1,5 +1,5 @@
 
-$default-spacing: 1em !default
+$default-spacing: 1em !default;
 
 $default-spacings: (
 	0: 0,


### PR DESCRIPTION
> Invalid CSS after "...g: 1em !default": expected selector or at-rule, was "$default-spacin...".

Works fine in development. However in production failed with the above message. Having said that, check semicolon's.